### PR TITLE
IntelliJ XML files not gitignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,7 @@ fabric.properties
 .idea/codestream.xml
 
 # End of https://www.toptal.com/developers/gitignore/api/intellij
+
+.idea/*.xml
+.idea/*.iml
+*.iml


### PR DESCRIPTION
When creating an IntelliJ project, the following files were not automatically ignored:
- .idea/misc.xml
- .idea/modules.xml
- .idea/vcs.xml
- training.iml